### PR TITLE
Add await when processing header to avoid unhandleRejection #698

### DIFF
--- a/src/lib/GoogleSpreadsheetWorksheet.ts
+++ b/src/lib/GoogleSpreadsheetWorksheet.ts
@@ -346,7 +346,7 @@ export class GoogleSpreadsheetWorksheet {
   async loadHeaderRow(headerRowIndex?: number) {
     if (headerRowIndex !== undefined) this._headerRowIndex = headerRowIndex;
     const rows = await this.getCellsInRange(this._headerRange);
-    this._processHeaderRow(rows);
+    await this._processHeaderRow(rows);
   }
 
   private async _processHeaderRow(rows: any[]) {


### PR DESCRIPTION
There was an await missing in the call to the `_processHeaderRow` function that would cause an `unhandledRejection` error when any error was encountered. The side effect of this is that the `unhandledRejection` error goes under the radar and results in a `uncaughtException` error that kills the Budibase server.

To reproduce
- Create a Google sheet. Ensure at least one of more of the sheets have no headers.
- Add the sheet to your datasources in Budibase.
- Click Fetch tables for Google sheet. Select all the sheets.
- Click Fetch Sheets. The import will fail and the server will crash with an unhandledRejection

Our koa app also needs a modification to better handle the unhandledRejection